### PR TITLE
Bugfix webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-init",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Script to initialize your webpack projects",
   "bin": {
     "webpack-init": "./bin/webpack-init.js"

--- a/src/installModules.js
+++ b/src/installModules.js
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process'
 
-export default function installModules({ loaders: modules }) {
-  spawn('npm', ['install', '--save-dev', ...modules])
+export default function installModules({ module }) {
+  spawn('npm', ['install', '--save-dev', ...module])
 }

--- a/src/promptInputs.js
+++ b/src/promptInputs.js
@@ -3,25 +3,25 @@ export const base = [
     type: 'input',
     name: 'configFileName',
     message: 'Enter the file name for your webpack config',
-    default() { return 'webpack.config.js' }
+    default: () => 'webpack.config.js'
   },
   {
     type: 'input',
     name: 'entry',
     message: 'Enter the filename for your entry',
-    default() { return 'index.js' }
+    default: () => 'index.js'
   },
   {
     type: 'input',
     name: 'outputPath',
     message: 'Enter the output path, this is where your images and js will be output at',
-    default() { return './' }
+    default: () => './'
   },
   {
     type: 'input',
     name: 'outputFilename',
     message: 'Enter the output filename',
-    default() { return 'bundle.js' }
+    default: () => 'bundle.js'
   },
   {
     type: 'confirm',


### PR DESCRIPTION
Was using the wrong syntax for webpack config. Fix this to put the loaders within the module object. Also fixed the issue where the output public path was always showing undefined.
